### PR TITLE
fix issue with building brackets with only 2/3 players

### DIFF
--- a/lib/ex_tournaments/utils/pairing_helpers.ex
+++ b/lib/ex_tournaments/utils/pairing_helpers.ex
@@ -37,12 +37,12 @@ defmodule ExTournaments.Utils.PairingHelpers do
   """
   @spec prefill_bracket(float()) :: list(integer())
   def prefill_bracket(exponent) do
-    if :math.floor(exponent) >= 3 do
-      Enum.reduce(3..trunc(:math.floor(exponent)), [1, 4, 2, 3], fn exponent, seeds ->
+    case :math.floor(exponent) do
+      result when result >= 3 -> Enum.reduce(3..trunc(result), [1, 4, 2, 3], fn exponent, seeds ->
         update_bracket(seeds, 0, exponent)
       end)
-    else
-      [1, 4, 2, 3]
+      result when result >= 2 -> [1, 4, 2, 3]
+      result when result >= 1 -> [1, 2]
     end
   end
 

--- a/test/pairings/single_elimination_test.exs
+++ b/test/pairings/single_elimination_test.exs
@@ -51,4 +51,17 @@ defmodule ExTournaments.Pairings.SingleEliminationTest do
       end
     end
   end
+
+  describe "generate_matches_for_3_players" do
+    matches = ExTournaments.Pairings.SingleElimination.call([1,2,3], 1, false, false)
+    assert Enum.count(matches) == 2
+  end
+
+  describe "generate_match_for_2_players" do
+    matches = ExTournaments.Pairings.SingleElimination.call([1,2], 1, false, false)
+    [match] = matches
+    # check if player 1 and player 2 are assigned
+    assert not is_nil(match.player1) && not is_nil(match.player2)
+
+  end
 end


### PR DESCRIPTION
This PR fixes an issue with creating single-elimination tournament brackets with 2 or 3 players.

This fixes test failures in the double reporting PR in the playstile repository.