### PR TITLE
change assign by logic

### DIFF
--- a/lib/ex_tournaments/pairings/swiss.ex
+++ b/lib/ex_tournaments/pairings/swiss.ex
@@ -201,12 +201,27 @@ defmodule ExTournaments.Pairings.Swiss do
   end
 
   defp assign_bye(players) when rem(length(players), 2) !== 0 do
-    bye =
-      players
+    # we might want to add a parameter to specify
+    # :swiss or :"2lo" different logic for :swiss
+    not_previous_bye_list = players
       |> Enum.reject(fn player ->
         player.received_bye
       end)
+
+    one_loss_players =
+      not_previous_bye_list
+      |> Enum.filter(&(&1.score == 1))
+    # if the 1 loss player list that have not got a bye
+    # is not empty, we take a random element from the list
+    bye = if Enum.empty?(one_loss_players) do
+      not_previous_bye_list
       |> Enum.random()
+    else
+    # otherwise we take a random element from the list
+    # of player that have not got a bye yet
+      one_loss_players
+      |> Enum.random()
+    end
 
     Enum.reject(players, &(&1.id == bye.id))
   end


### PR DESCRIPTION
Change the assign_bye method in swiss to assign the bye to the X-1 pool of participants.

Looks like the match making does not use the GSOS to pair players and the pairing is somehow random.

I could be mistaken but I do not think that the Blossom algorithm avoids rematches between players.
